### PR TITLE
Fix use of {{partial}} inside block helper like {{each}}

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -8,45 +8,63 @@ module.exports = function(Handlebars, getTemplate) {
   var oldEach = Handlebars.helpers.each;
 
   return {
-    view: function(viewName, block) {
-      var ViewClass, html, options, view, data;
+    view: function(viewName, options) {
+      var ViewClass, html, viewOptions, view;
 
       BaseView = BaseView || require('rendr/shared/base/view');
       modelUtils = modelUtils || require('rendr/shared/modelUtils');
       viewName = modelUtils.underscorize(viewName);
-      options = block.hash || {};
-      data = block.data || {};
+      viewOptions = options.hash || {};
 
       // Pass through a reference to the app.
-      var app = this._app || data._app;
+      var app = getProperty('_app', this, options);
       if (app) {
-        options.app = app;
+        viewOptions.app = app;
       }
 
       // Pass through a reference to the parent view.
-      parentView = this._view || data._view
+      var parentView = getProperty('_view', this, options);
       if (parentView) {
-        options.parentView = parentView;
+        viewOptions.parentView = parentView;
       }
 
       // get the Backbone.View based on viewName
       ViewClass = BaseView.getView(viewName);
-      view = new ViewClass(options);
+      view = new ViewClass(viewOptions);
 
       // create the outerHTML using className, tagName
       html = view.getHtml();
       return new Handlebars.SafeString(html);
     },
 
-    partial: function(templateName, block) {
-      var data, html, options, template;
+    partial: function(templateName, options) {
+      var data, html, context, template;
 
       template = getTemplate(templateName);
-      options = block.hash || {};
-      data = _.isEmpty(options) ? this : options.context ? options.context : options;
-      data = _.clone(data);
-      data._app = data._app || this._app;
-      html = template(data);
+
+      context = options.hash || {};
+
+      // First try to use Handlebars' hash arguments as the context for the
+      // partial, if present.
+      //
+      // ex: `{{partial "users/photo" user=user}}`
+      if (_.isEmpty(context)) {
+        // If there are no hash arguments given, then inherit the parent context.
+        //
+        // ex: `{{partial "users/photo"}}`
+        context = this;
+      } else {
+        // If a hash argument is given with key `context`, then use that as the context.
+        //
+        // ex: `{{partial "users/photo" context=user}}`
+        if (context.hasOwnProperty('context')) {
+          context = context.context;
+        }
+      }
+      context = _.clone(context);
+
+      context._app = getProperty('_app', this, options);
+      html = template(context);
       return new Handlebars.SafeString(html);
     },
 
@@ -92,4 +110,14 @@ function getOptionsFromContext(obj) {
   }, {});
 
   return options;
+}
+
+/**
+ * Get a property that is being passed down through helpers, such as `_app`
+ * or `_view`. It can either live on the context, i.e. `this._app`, or in the
+ * `options.data` object passed to the helper, i.e. `options.data._app`, in the
+ * case of a block helper like `each`.
+ */
+function getProperty(key, context, options) {
+  return context[key] || (options.data || {})[key];
 }


### PR DESCRIPTION
Before, `{{partial}}` was incorrectly looking for the `_app` property; it
could find it in the helper context (`this._app`), but not in the helper
options (`options.data._app`), which are utilized by block helpers like
`{{#each}}` for passing through the app context.

This adds a `getProperty(key, context, options)` method which DRYs up that
logic.

Also cleans up the context logic in `{{partial}}`.

/cc @jacoblwe20 @91bananas
