### PR TITLE
move rendr dependency to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Spike Brehm <spike@airbnb.com>",
   "license": "MIT",
   "engines": {
-    "npm": ">=1.2"
+    "npm": ">=1.2.10"
   },
   "devDependencies": {
     "mocha": "~1.12.0"


### PR DESCRIPTION
This prevents having another copy of rendr lying around and just ensures that the module which depends on rendr-handlebars will also depend on rendr itself. Requires node >= 0.8.19, see the [blog post](http://blog.nodejs.org/2013/02/07/peer-dependencies/) for more details.
