### PR TITLE
Update helpers.js

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -71,8 +71,8 @@ module.exports = function(Handlebars, getTemplate) {
       return new Handlebars.SafeString(html);
     },
 
-    json: function(object) {
-      return new Handlebars.SafeString(JSON.stringify(object) || 'null');
+    json: function(object, spacing) {
+      return new Handlebars.SafeString(JSON.stringify(object, null, spacing) || 'null');
     },
 
     /**


### PR DESCRIPTION
This adds an option to space the JSON when it's being output. By writing the new helper like this:

```
{{json user 4}}
```

the JSON output goes from a flat, un-parseable list....

![](http://content.screencast.com/users/matt.pardee/folders/Jing/media/e05af00f-d88b-4736-b5fd-8cc178ffb452/00000146.png)

to

![](http://content.screencast.com/users/matt.pardee/folders/Jing/media/e98f1edc-d86c-459d-9a68-d01ae0716b27/00000145.png)
