### PR TITLE
use app.viewAdapter instead of hardcoded BaseView

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -25,7 +25,7 @@ module.exports = function(Handlebars, getTemplate) {
       }
 
       // get the Backbone.View based on viewName
-      ViewClass = app.viewAdapter.getView(viewName, app.options.entryPath);
+      ViewClass = app.getView(viewName, app.options.entryPath);
       view = new ViewClass(viewOptions);
 
       // create the outerHTML using className, tagName

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -1,8 +1,5 @@
 var _ = require('underscore');
 
-// Lazy-required.
-var BaseView = null;
-
 module.exports = function(Handlebars, getTemplate) {
   var oldEach = Handlebars.helpers.each;
 
@@ -10,10 +7,6 @@ module.exports = function(Handlebars, getTemplate) {
     view: function(viewName, options) {
       var ViewClass, html, viewOptions, view;
 
-      // it's lazy loaded, not a compile time dependency
-      // hiding it from r.js compiler
-      var lazyRequire_baseView = 'rendr/shared/base/view';
-      BaseView = BaseView || require(lazyRequire_baseView);
       viewOptions = options.hash || {};
 
       // Pass through a reference to the app.
@@ -32,7 +25,7 @@ module.exports = function(Handlebars, getTemplate) {
       }
 
       // get the Backbone.View based on viewName
-      ViewClass = BaseView.getView(viewName, app.options.entryPath);
+      ViewClass = app.viewAdapter.getView(viewName, app.options.entryPath);
       view = new ViewClass(viewOptions);
 
       // create the outerHTML using className, tagName


### PR DESCRIPTION
This is a matching commit for airbnb/rendr#250, making use of app's viewAdapter instead of pulling in nested requires from rendr.