### PR TITLE
JSON-safe != HTML-safe

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -72,7 +72,9 @@ module.exports = function(Handlebars, getTemplate) {
     },
 
     json: function(object, spacing) {
-      return new Handlebars.SafeString(JSON.stringify(object, null, spacing) || 'null');
+      return new Handlebars.SafeString(
+        JSON.stringify(object, null, spacing).replace(/\//g, '\\/') || 'null'
+      );
     },
 
     /**


### PR DESCRIPTION
JSON.stringify enables you to safely include an untrusted string in JavaScript, it's true. But when bootstrapping model data, the bootstrap JavaScript is wrapped in an HTML container (i.e. inline script tag). That means that a string like "`</script>`", which is a valid JavaScript string, will cause the HTML container to think that the JavaScript section has ended, which is an exploitable vulnerability. For an example, visit http://localhost:3030/users/CGamesPlay in the first Rendr example.

I believe this issue resides in rendr-handlebars because handlebars is typically used to make HTML documents, and so the json helper should assume that the output from the function (the SafeString, as it's called) will be included in an HTML container.

It should be possible to fix this up by replacing all `'/'` with `'\\/'`, but that may have performance implications if the bootstrapped data isn't gzipped... seems unlikely though. Thoughts?
