### PR TITLE
don’t hide the require path from browserify

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -1,4 +1,6 @@
-var _ = require('underscore');
+var _ = require('underscore'),
+  isServer = typeof window === 'undefined',
+  isAMDEnvironment = !isServer && (typeof define !== 'undefined');
 
 // Lazy-required.
 var BaseView = null;
@@ -10,10 +12,16 @@ module.exports = function(Handlebars, getTemplate) {
     view: function(viewName, options) {
       var ViewClass, html, viewOptions, view;
 
-      // it's lazy loaded, not a compile time dependency
-      // hiding it from r.js compiler
-      var lazyRequire_baseView = 'rendr/shared/base/view';
-      BaseView = BaseView || require(lazyRequire_baseView);
+      if (!BaseView) {
+        if (isAMDEnvironment) {
+          // it's lazy loaded, not a compile time dependency
+          // hiding it from r.js compiler
+          var lazyRequire_baseView = 'rendr/shared/base/view';
+          BaseView = require(lazyRequire_baseView);
+        } else {
+          BaseView = require('rendr/shared/base/view');
+        }
+      }
       viewOptions = options.hash || {};
 
       // Pass through a reference to the app.


### PR DESCRIPTION
This fixes the issue described in https://github.com/airbnb/rendr/pull/260.
