### PR TITLE
Upgrade to handlebars@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "underscore": "1.5.2",
-    "handlebars": "git://github.com/spikebrehm/handlebars.js.git#6bbcf3f2225b0e62d249481d07456698da7da65e"
+    "handlebars": "1.3.0"
   },
   "peerDependencies": {
     "rendr": ">=0.5.0-rc1"


### PR DESCRIPTION
Now that Handlebars properly supports CommonJS builds, use the real
module rather than a fork.

Tested with airbnb/rendr#HEAD.

@c089 @lo1tuma 
