### PR TITLE
[RFC] Removed lazyLoading circus.

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -1,6 +1,5 @@
 var _ = require('underscore'),
-  isServer = typeof window === 'undefined',
-  isAMDEnvironment = !isServer && (typeof define !== 'undefined');
+  isServer = typeof window === 'undefined';
 
 // Lazy-required.
 var BaseView = null,
@@ -14,14 +13,7 @@ module.exports = function(Handlebars, getTemplate) {
       var ViewClass, html, viewOptions, view;
 
       if (!BaseView) {
-        if (isAMDEnvironment) {
-          // it's lazy loaded, not a compile time dependency
-          // hiding it from r.js compiler
-          var lazyRequire_baseView = 'rendr/shared/base/view';
-          BaseView = require(lazyRequire_baseView);
-        } else {
-          BaseView = require('rendr/shared/base/view');
-        }
+        BaseView = require('rendr/shared/base/view');
       }
       viewOptions = options.hash || {};
 


### PR DESCRIPTION
If `browserify` couldn't live without explicit dependency, then we'll add workaround for AMD loader.

Although I don't think it shouldn't hardcoded like that, since `rendr` is a peerDependency, but I understand that it's probably 95% of use cases.

Before merging I'd like to hear your guys opinion from architectural point of view.

/cc @spikebrehm @c089 @lo1tuma 
