### PR TITLE
change urls to new GH organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![travis-ci status](https://secure.travis-ci.org/airbnb/rendr-handlebars.png)](http://travis-ci.org/#!/airbnb/rendr-handlebars/builds)
-[![Dependency Status](https://david-dm.org/airbnb/rendr-handlebars.png)](https://david-dm.org/airbnb/rendr-handlebars)
+[![travis-ci status](https://secure.travis-ci.org/rendrjs/rendr-handlebars.png)](http://travis-ci.org/#!/rendrjs/rendr-handlebars/builds)
+[![Dependency Status](https://david-dm.org/rendrjs/rendr-handlebars.png)](https://david-dm.org/rendrjs/rendr-handlebars)
 
 rendr-handlebars
 ================
 
-[Handlebars](http://handlebarsjs.com/) template adapter for [Rendr](https://github.com/airbnb/rendr) apps.
+[Handlebars](http://handlebarsjs.com/) template adapter for [Rendr](https://github.com/rendrjs/rendr) apps.


### PR DESCRIPTION
This changes all urls to the new github organization.
