### PR TITLE
Bump to 0.2.0 for rendr@0.5.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
-# 0.2.0-rc1
-## 2013-12-13
+# 0.2.0
+## 2014-02-25
 * Add support for AMD modules.
+* Upgraded to Handlebars@1.3.0.
+* Upgraded to Underscore@1.5.2.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rendr-handlebars",
-  "version": "0.2.0-rc2",
+  "version": "0.2.0",
   "description": "Glue handlebars templates into a Rendr app.",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "handlebars": "1.3.0"
   },
   "peerDependencies": {
-    "rendr": ">=0.5.0-rc2"
+    "rendr": ">=0.5.0"
   },
   "keywords": [
     "rendr",


### PR DESCRIPTION
To match https://github.com/rendrjs/rendr/pull/331
