### PR TITLE
Added the ability to have a partial take an optional block.

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -36,6 +36,11 @@ module.exports = function(Handlebars, getTemplate) {
       ViewClass = BaseView.getView(viewName, app.options.entryPath);
       view = new ViewClass(viewOptions);
 
+      // Allows passing a block into the partial function as well.
+      if(_.isFunction(options.fn)) {
+        context._block = options.fn(context)
+      }
+
       // create the outerHTML using className, tagName
       html = view.getHtml();
       return new Handlebars.SafeString(html);
@@ -108,7 +113,8 @@ function getOptionsFromContext(obj) {
     '_app',
     '_view',
     '_model',
-    '_collection'
+    '_collection',
+    '_block'
   ];
 
   options = keys.reduce(function(memo, key) {

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -68,6 +68,12 @@ module.exports = function(Handlebars, getTemplate) {
       context = _.clone(context);
 
       context._app = getProperty('_app', this, options);
+
+      // Allows passing a block into the partial function as well.
+      if(_.isFunction(options.fn)) {
+        context._block = options.fn(context)
+      }
+
       html = template(context);
       return new Handlebars.SafeString(html);
     },


### PR DESCRIPTION
This will allow people to do...

```
{{#partial "myPartial" context=user}}
  h1 {{name}}
  <div class="description">{{description}}</div>
{{/partial}}
```

So we can have an overall partial that has a block but still called in the correct context.

@lo1tuma @spikebrehm what do you guys think?