### PR TITLE
Adding client side call to view.remove() to fix memory leak

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -38,6 +38,9 @@ module.exports = function(Handlebars, getTemplate) {
 
       // create the outerHTML using className, tagName
       html = view.getHtml();
+      if (!isServer) {
+        view.remove();
+      }
       return new Handlebars.SafeString(html);
     },
 


### PR DESCRIPTION
Not calling view.remove caused memory leaks in case of, for example, subscribing to any events in a view. This resulted in a big memory leaks, as parent views were also leaking because of parentView reference.