### PR TITLE
Stringify object attributes

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -54,7 +54,7 @@ module.exports = function(Handlebars, getTemplate) {
 
       // create a list of data attributes
       var attrString = _.inject(viewOptions, function(memo, value, key) {
-        return memo += " data-" + key + "=\"" + _.escape(value) + "\"";
+        return memo += " data-" + key + "=\"" + _.escape(typeof value === 'object' ? JSON.stringify(value) : value) + "\"";
       }, '');
 
       return new Handlebars.SafeString(


### PR DESCRIPTION
Previously, escaping object attributes would simply call the object's `toString` method which would output as `[object Object]` - losing the entire object. This ensures the object is properly stringified and then escaped.

@saponifi3d we should work on updating the tests to be more comprehensive