### PR TITLE
Stringify arrays when returning string for client placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "memo-is": "0.0.2",
     "mocha": "~2.1.0",
     "sinon": "~1.12.2",
-    "sinon-chai": "~2.6.0"
+    "sinon-chai": "~2.6.0",
+    "proxyquire": "^1.3.1"
   }
 }

--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -4,12 +4,12 @@
 
 var _ = require('underscore'),
     getProperty = require('../../lib/getProperty'),
-    isServer = typeof window === 'undefined',
     BaseView;
 
 module.exports = function (Handlebars) {
   return function (viewName, options) {
-    var ViewClass, html, viewOptions, view, app;
+    var isServer = typeof window === 'undefined',
+        html, viewOptions, view, app;
 
     viewOptions = options.hash || {};
     app = getProperty('_app', this, options);
@@ -39,6 +39,8 @@ module.exports = function (Handlebars) {
 };
 
 function getServerHtml(viewName, viewOptions, parentView) {
+  var ViewClass, view;
+
   if (!BaseView) { BaseView = require('rendr/shared/base/view'); }
 
   // Pass through a reference to the parent view.
@@ -66,8 +68,9 @@ function getClientPlaceholder(viewName, viewOptions) {
 
   // create a list of data attributes
   var attrString = _.inject(viewOptions, function(memo, value, key) {
+    if (_.isArray(value)) { value = JSON.stringify(value); }
     return memo += " data-" + key + "=\"" + _.escape(value) + "\"";
   }, '');
 
-  return '<div data-render="true" ' + attrString +' data-view="'+ viewName +'"></div>';
+  return '<div data-render="true"' + attrString +' data-view="'+ viewName +'"></div>';
 }

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -1,30 +1,114 @@
 var Handlebars = require('handlebars').create(),
     memo = require('memo-is'),
-    sinon = require('sinon'),
     chai = require('chai'),
+    proxyquire = require('proxyquire').noCallThru(),
     expect = chai.expect,
-    subject = require('../../../shared/helpers/view')(Handlebars);
+    BaseViewStub = {
+      getView: function (viewName, entryPath) {
+        return ViewClass;
+      },
+      parseModelAndCollection: function (modelUtils, viewOptions) {
+        return viewOptions;
+      },
+      extractFetchSummary: memo().is(function() {
+        return {};
+      })
+    },
+    subject = proxyquire('../../../shared/helpers/view', {
+      'rendr/shared/base/view': BaseViewStub
+    })(Handlebars);
+
+function ViewClass() {}
+
+ViewClass.prototype.getHtml = function () {
+  return '<p>Foo</p>'
+};
 
 describe('view', function () {
-  var app = memo().is(function() {
-    return {
-      modelUtils: {
-        underscorize: function (name) { return name }
-      }
-    }
-  });
+  var app = memo().is(function () {
+        return {
+          options: { entryPath: '/path' },
+          modelUtils: {
+            underscorize: function (name) { return name }
+          }
+        };
+      });
 
   context('server-side', function () {
-    it('should error if there is no app in the options', function () {
-      expect(function () {
-        subject('test')
-      }).to.throw(Error)
+    before(function () {
+      GLOBAL.window = undefined;
     });
 
-    it('returns a string with the html');
+    it('should error if there is no app in the options', function () {
+      expect(function () {
+        subject('test');
+      }).to.throw(Error);
+    });
+
+    it("returns the result of the view instance's getHtml method", function() {
+      var result = subject('test', {
+        data: { '_app': app() }
+      });
+      expect(result.string).to.eq('<p>Foo</p>');
+    });
   });
 
   context('client-side', function () {
-    it('should create a string with data-render set to true');
+    before(function () {
+      GLOBAL.window = true;
+    });
+
+    after(function () {
+      GLOBAL.window = undefined;
+    });
+
+    context('when extractFetchSummary returns an empty object', function () {
+      it('creates a string with data-render set to true', function () {
+        var result = subject('test', {
+          data: {'_app': app() }
+        });
+        expect(result.string).to.eq(
+          '<div data-render="true" data-fetch_summary="{}" data-view="test"></div>'
+        )
+      });
+    });
+
+    context('when extractFetchSummary returns a model', function () {
+      BaseViewStub.extractFetchSummary.is(function () {
+        return {
+          model: {
+            model: 'SomeModel',
+            id: 1
+          }
+        };
+      });
+
+      it('includes the fetch summary for the model', function () {
+        var result = subject('test', {
+          data: { '_app': app() }
+        });
+        expect(result.string).to.eq(
+          '<div data-render="true" data-fetch_summary="{&quot;model&quot;:{&quot;model&quot;:&quot;SomeModel&quot;,&quot;id&quot;:1}}" data-view="test"></div>'
+        )
+      });
+    });
+
+    context('when the viewOptions contain arrays', function () {
+      it('serializes the arrays correctly', function () {
+        var result = subject('test', {
+          data: {
+            '_app': app()
+          },
+          hash: {
+            number_array: [1, 2, 3],
+            string_array: ['foo', 'bar'],
+            object_array: [{ foo: 'bar', foo: 'baz' }]
+          }
+        });
+        expect(result.string).to.eq(
+          '<div data-render="true" data-number_array="[1,2,3]" data-string_array="[&quot;foo&quot;,&quot;bar&quot;]" data-object_array="[{&quot;foo&quot;:&quot;baz&quot;}]" data-fetch_summary="{}" data-view="test"></div>'
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue where arrays of objects that were passed into a view via the `view` helper would get incorrectly set. Before, an array of objects would get returned as `data-some-array="[Object object, Object object]"`.

Also updated the test suite for the view helper and introduced proxyquire to stub out the Rendr dependencies.