### PR TITLE
Fix for circular dependency for models / collections / app

### DIFF
--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -68,7 +68,13 @@ function getClientPlaceholder(viewName, viewOptions) {
 
   // create a list of data attributes
   var attrString = _.inject(viewOptions, function(memo, value, key) {
-    if (_.isArray(value) || _.isObject(value)) { value = JSON.stringify(value); }
+    if (_.isArray(value) || _.isObject(value)) {
+      if (typeof value.toJSON === 'function') {
+        value = value.toJSON();
+      } else {
+        value = JSON.stringify(value);
+      }
+    }
     return memo += " data-" + key + "=\"" + _.escape(value) + "\"";
   }, '');
 

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -1,6 +1,7 @@
 var Handlebars = require('handlebars').create(),
     memo = require('memo-is'),
     chai = require('chai'),
+    sinon = require('sinon'),
     proxyquire = require('proxyquire').noCallThru(),
     expect = chai.expect,
     BaseViewStub = {
@@ -30,7 +31,8 @@ describe('view', function () {
           options: { entryPath: '/path' },
           modelUtils: {
             underscorize: function (name) { return name }
-          }
+          },
+          toJSON: sinon.spy()
         };
       });
 
@@ -108,6 +110,19 @@ describe('view', function () {
         expect(result.string).to.eq(
           '<div data-render="true" data-number_array="[1,2,3]" data-string_array="[&quot;foo&quot;,&quot;bar&quot;]" data-object_array="[{&quot;foo&quot;:&quot;baz&quot;}]" data-fetch_summary="{}" data-view="test"></div>'
         );
+      });
+    });
+
+    context('when the viewOptions contains a model', function () {
+      it('invokes the toJSON property', function () {
+        var result = subject('test', {
+          data: {
+            '_app': app()
+          },
+          hash: { '_app': app() }
+        });
+
+        expect(app().toJSON).to.have.been.called
       });
     });
 


### PR DESCRIPTION
Having issues fixing it for _all_ cases, but this is at least a fix if someone passes an attribute that has a `toJSON` function.

Prefer having the error and one with decent context than trying to insert something that *might* be what they intended.