### PR TITLE
Don't include data attributes that are present in the fetch summary

### DIFF
--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -62,10 +62,8 @@ function getClientPlaceholder(viewName, viewOptions) {
   // Builds a fetch_summary attribute
   viewOptions = BaseView.parseModelAndCollection(viewOptions.app.modelUtils, viewOptions);
   fetchSummary = BaseView.extractFetchSummary(viewOptions.app.modelUtils, viewOptions);
-  fetchSummary = JSON.stringify(fetchSummary)
-
   viewOptions['fetch_summary'] = fetchSummary
-  viewOptions = _.omit(viewOptions, ['model', 'collection', 'app'])
+  viewOptions = _.omit(viewOptions, _.keys(fetchSummary).concat(['model', 'collection', 'app']));
 
   // create a list of data attributes
   var attrString = _.inject(viewOptions, function(memo, value, key) {

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -64,9 +64,10 @@ describe('view', function () {
     });
 
     it("returns the result of the view instance's getHtml method", function() {
-      var result = subject('test', {
-        data: { '_app': app() }
-      });
+      var result = subject.call({
+        _app: app()
+      }, 'test', {});
+
       expect(result.string).to.eq('<p>Foo</p>');
     });
   });
@@ -82,9 +83,10 @@ describe('view', function () {
 
     context('when extractFetchSummary returns an empty object', function () {
       it('creates a string with data-render set to true', function () {
-        var result = subject('test', {
-          data: {'_app': app() }
-        });
+        var result = subject.call({
+          _app: app()
+        }, 'test', {});
+
         expect(result.string).to.eq(
           '<div data-render="true" data-fetch_summary="{}" data-view="test"></div>'
         )
@@ -102,10 +104,9 @@ describe('view', function () {
       });
 
       it('includes the fetch summary for the model and does not include a data-attribute for the model', function () {
-        var result = subject('test', {
-          data: {
-            '_app': app()
-          },
+        var result = subject.call({
+          _app: app()
+        }, 'test', {
           hash: {
             some_model: new ModelClass()
           }
@@ -127,10 +128,9 @@ describe('view', function () {
       });
 
       it('includes the fetch summary for the collection and does not include a data-attribute for the collection', function () {
-        var result = subject('test', {
-          data: {
-            '_app': app()
-          },
+        var result = subject.call({
+          _app: app()
+        }, 'test', {
           hash: {
             some_collection: new CollectionClass()
           }
@@ -143,10 +143,9 @@ describe('view', function () {
 
     context('when the viewOptions contain arrays', function () {
       it('serializes the arrays correctly', function () {
-        var result = subject('test', {
-          data: {
-            '_app': app()
-          },
+        var result = subject.call({
+          _app: app()
+        }, 'test', {
           hash: {
             number_array: [1, 2, 3],
             string_array: ['foo', 'bar'],
@@ -161,10 +160,9 @@ describe('view', function () {
 
     context('when the viewOptions contains an object', function () {
       it('serializes the object correctly', function () {
-        var result = subject('test', {
-          data: {
-            '_app': app()
-          },
+        var result = subject.call({
+          _app: app()
+        }, 'test', {
           hash: {
             generic_object: {
               a: 1,

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -25,12 +25,16 @@ ViewClass.prototype.getHtml = function () {
   return '<p>Foo</p>'
 };
 
+function ModelClass() {}
+
+function CollectionClass() {}
+
 describe('view', function () {
   var app = memo().is(function () {
         return {
           options: { entryPath: '/path' },
           modelUtils: {
-            underscorize: function (name) { return name }
+            underscorize: function (name) { return name; }
           }
         };
       });
@@ -90,19 +94,49 @@ describe('view', function () {
     context('when extractFetchSummary returns a model', function () {
       BaseViewStub.extractFetchSummary.is(function () {
         return {
-          model: {
-            model: 'SomeModel',
+          some_model: {
+            model: 'ModelClass',
             id: 1
           }
         };
       });
 
-      it('includes the fetch summary for the model', function () {
+      it('includes the fetch summary for the model and does not include a data-attribute for the model', function () {
         var result = subject('test', {
-          data: { '_app': app() }
+          data: {
+            '_app': app()
+          },
+          hash: {
+            some_model: new ModelClass()
+          }
         });
         expect(result.string).to.eq(
-          '<div data-render="true" data-fetch_summary="{&quot;model&quot;:{&quot;model&quot;:&quot;SomeModel&quot;,&quot;id&quot;:1}}" data-view="test"></div>'
+          '<div data-render="true" data-fetch_summary="{&quot;some_model&quot;:{&quot;model&quot;:&quot;ModelClass&quot;,&quot;id&quot;:1}}" data-view="test"></div>'
+        )
+      });
+    });
+
+    context('when extractFetchSummary returns a collection', function () {
+      BaseViewStub.extractFetchSummary.is(function () {
+        return {
+          some_collection: {
+            collection: 'CollectionClass',
+            id: 1
+          }
+        };
+      });
+
+      it('includes the fetch summary for the collection and does not include a data-attribute for the collection', function () {
+        var result = subject('test', {
+          data: {
+            '_app': app()
+          },
+          hash: {
+            some_collection: new CollectionClass()
+          }
+        });
+        expect(result.string).to.eq(
+          '<div data-render="true" data-fetch_summary="{&quot;some_collection&quot;:{&quot;collection&quot;:&quot;CollectionClass&quot;,&quot;id&quot;:1}}" data-view="test"></div>'
         )
       });
     });


### PR DESCRIPTION
Addresses: https://github.com/rendrjs/rendr-handlebars/issues/44

@saponifi3d 

When returning the client placeholder for a view, we currently add data attributes that are later ignored because the models/collections are actually fetched via the fetch_params. This PR updates the view helper so that it doesn't add these unnecessary data attributes, resulting in a much smaller DOM.