### PR TITLE
add serverToClientJson helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "http://github.com/rendrjs/rendr-handlebars.git"
   },
   "dependencies": {
-    "underscore": "~1.7.0",
-    "handlebars": "1.3.0"
+    "handlebars": "1.3.0",
+    "underscore": "~1.7.0"
   },
   "peerDependencies": {
     "rendr": ">=0.5.1"

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -4,6 +4,7 @@ module.exports = function(Handlebars, getTemplate) {
     partial: require('./helpers/partial')(Handlebars, getTemplate),
     json: require('./helpers/json')(Handlebars),
     each: require('./helpers/each')(Handlebars),
+    serverToClientJson: require('./helpers/serverToClientJson')(Handlebars),
     forEach: require('./helpers/forEach')
   };
 };

--- a/shared/helpers/serverToClientJson.js
+++ b/shared/helpers/serverToClientJson.js
@@ -1,0 +1,6 @@
+module.exports = function (Handlebars) {
+  return function (obj) {
+    var data = escape(JSON.stringify(obj));
+    return new Handlebars.SafeString('JSON.parse(unescape("' + data + '"))');
+  };
+};

--- a/test/shared/helpers.test.js
+++ b/test/shared/helpers.test.js
@@ -21,5 +21,6 @@ describe('helpers', function () {
     expect(subject.forEach).to.be.a('function');
     expect(subject.partial).to.be.a('function');
     expect(subject.view).to.be.a('function');
+    expect(subject.serverToClientJson).to.be.a('function');
   });
 });

--- a/test/shared/helpers/serverToClientJson.test.js
+++ b/test/shared/helpers/serverToClientJson.test.js
@@ -1,0 +1,14 @@
+var Handlebars = require('handlebars').create(),
+    sinon = require('sinon'),
+    chai = require('chai'),
+    expect = chai.expect,
+    subject = require('../../../shared/helpers/serverToClientJson')(Handlebars);
+
+describe('serverToClientJson', function () {
+  var data = { key: 'права' }
+
+  it('should add JSON.parse and unescape to the string', function () {
+    var result = subject(data);
+    expect(eval(result.string)).to.deep.equal(data);
+  });
+});

--- a/test/shared/helpers/serverToClientJson.test.js
+++ b/test/shared/helpers/serverToClientJson.test.js
@@ -8,7 +8,15 @@ describe('serverToClientJson', function () {
   var data = { key: 'права' }
 
   it('should add JSON.parse and unescape to the string', function () {
+    var result = subject(data),
+        expectedResult = 'JSON.parse(unescape("%7B%22key%22%3A%22%u043F%u0440%u0430%u0432%u0430%22%7D"))';
+
+    expect(expectedResult).to.equal(result.string);
+  });
+
+  it('should result in the same data after eval', function () {
     var result = subject(data);
     expect(eval(result.string)).to.deep.equal(data);
   });
+
 });


### PR DESCRIPTION
This should be set when you pass any data from the server to the client in a consistent manner.

I was having a lot of problems getting [sanitizer](https://www.npmjs.com/package/sanitizer) to be on the client-side correctly without hacking outside of rendr-handlebars. Any suggestions on how we can pass the `sanitizer.unescapeEntities` function to the client easily (without munging w/ build tools) would be awesome.