### PR TITLE
upgrade dependencies and fix tests that broke when upgrading chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "url": "http://github.com/rendrjs/rendr-handlebars.git"
   },
   "dependencies": {
-    "handlebars": "1.3.0",
-    "underscore": "~1.7.0"
+    "handlebars": "^2.0.0",
+    "underscore": "^1.8.2"
   },
   "peerDependencies": {
-    "rendr": ">=0.5.1"
+    "rendr": ">=1.0.0"
   },
   "keywords": [
     "rendr",
@@ -29,11 +29,11 @@
   },
   "devDependencies": {
     "backbone": "~1.1.2",
-    "chai": "~1.10.0",
+    "chai": "^2.1.0",
     "memo-is": "0.0.2",
     "mocha": "~2.1.0",
     "sinon": "~1.12.2",
-    "sinon-chai": "~2.6.0",
+    "sinon-chai": "^2.7.0",
     "proxyquire": "^1.3.1"
   }
 }

--- a/test/shared/helpers/forEach.test.js
+++ b/test/shared/helpers/forEach.test.js
@@ -64,10 +64,10 @@ describe('forEach', function () {
       var thisCall = spy.getCall(0),
           args = thisCall.args[0];
 
-      expect(args._app).to.deep.equal(scope.app);
-      expect(args._view).to.deep.equal(scope.view);
-      expect(args._model).to.deep.equal(scope.model);
-      expect(args._collection).to.deep.equal(scope.collection);
+      expect(args).to.have.property('_app').that.deep.equals(scope.app);
+      expect(args).to.have.property('_view').that.deep.equals(scope.view);
+      expect(args).to.have.property('_model').that.deep.equals(scope.model);
+      expect(args).to.have.property('_collection').that.deep.equals(scope.collection);
     })
 
     it('will have the private properties attached if it is nested in another helper', function () {
@@ -84,10 +84,10 @@ describe('forEach', function () {
       var thisCall = spy.getCall(0),
           args = thisCall.args[0];
 
-      expect(args._app).to.deep.equal(scope._app);
-      expect(args._view).to.deep.equal(scope._view);
-      expect(args._model).to.deep.equal(scope._model);
-      expect(args._collection).to.deep.equal(scope._collection);
+      expect(args).to.have.property('_app').that.deep.equals(scope._app);
+      expect(args).to.have.property('_view').that.deep.equals(scope._view);
+      expect(args).to.have.property('_model').that.deep.equals(scope._model);
+      expect(args).to.have.property('_collection').that.deep.equals(scope._collection);
     });
   });
 

--- a/test/shared/helpers/forEach.test.js
+++ b/test/shared/helpers/forEach.test.js
@@ -103,11 +103,11 @@ describe('forEach', function () {
       var thisCall = spy.getCall(0),
           args = thisCall.args[0];
 
-      expect(args).to.deep.property('key', 0);
-      expect(args).to.deep.property('value', 'a');
-      expect(args).to.deep.property('_isFirst', true);
-      expect(args).to.deep.property('_isLast', false);
-      expect(args).to.deep.property('_total', 3);
+      expect(args.key).to.equal(0);
+      expect(args.value).to.equal('a');
+      expect(args._isFirst).to.equal(true);
+      expect(args._isLast).to.equal(false);
+      expect(args._total).to.equal(3);
     });
 
     it('calls opts.fn correctly for the middle element', function () {
@@ -117,9 +117,9 @@ describe('forEach', function () {
       var thisCall = spy.getCall(1),
           args = thisCall.args[0];
 
-      expect(args).to.deep.property('key', 1);
-      expect(args).to.deep.property('_isFirst', false);
-      expect(args).to.deep.property('_isLast', false);
+      expect(args.key).to.equal(1);
+      expect(args._isFirst).to.equal(false);
+      expect(args._isLast).to.equal(false);
     });
 
     it('calls opts.fn correctly for the last element', function () {
@@ -129,8 +129,8 @@ describe('forEach', function () {
       var thisCall = spy.getCall(2),
           args = thisCall.args[0];
 
-      expect(args).to.deep.property('key', 2);
-      expect(args).to.deep.property('_isLast', true);
+      expect(args.key).to.equal(2);
+      expect(args._isLast).to.equal(true);
     });
   });
 

--- a/test/shared/helpers/forEach.test.js
+++ b/test/shared/helpers/forEach.test.js
@@ -46,8 +46,8 @@ describe('forEach', function () {
       var thisCall = spy.getCall(0),
           args = thisCall.args[0];
 
-      expect(args.key).to.equal('a');
-      expect(args.value).to.equal('b');
+      expect(args).to.have.property('key', 'a');
+      expect(args).to.have.property('value', 'b');
     })
 
     it('will have the private properties attached', function () {
@@ -103,11 +103,11 @@ describe('forEach', function () {
       var thisCall = spy.getCall(0),
           args = thisCall.args[0];
 
-      expect(args.key).to.equal(0);
-      expect(args.value).to.equal('a');
-      expect(args._isFirst).to.equal(true);
-      expect(args._isLast).to.equal(false);
-      expect(args._total).to.equal(3);
+      expect(args).to.have.property('key', 0);
+      expect(args).to.have.property('value', 'a');
+      expect(args).to.have.property('_isFirst', true);
+      expect(args).to.have.property('_isLast', false);
+      expect(args).to.have.property('_total', 3);
     });
 
     it('calls opts.fn correctly for the middle element', function () {
@@ -117,9 +117,9 @@ describe('forEach', function () {
       var thisCall = spy.getCall(1),
           args = thisCall.args[0];
 
-      expect(args.key).to.equal(1);
-      expect(args._isFirst).to.equal(false);
-      expect(args._isLast).to.equal(false);
+      expect(args).to.have.property('key', 1);
+      expect(args).to.have.property('_isFirst', false);
+      expect(args).to.have.property('_isLast', false);
     });
 
     it('calls opts.fn correctly for the last element', function () {
@@ -129,8 +129,8 @@ describe('forEach', function () {
       var thisCall = spy.getCall(2),
           args = thisCall.args[0];
 
-      expect(args.key).to.equal(2);
-      expect(args._isLast).to.equal(true);
+      expect(args).to.have.property('key', 2);
+      expect(args).to.have.property('_isLast', true);
     });
   });
 
@@ -174,9 +174,9 @@ describe('forEach', function () {
         var thisCall = spy.getCall(0),
             args = thisCall.args[0];
 
-        expect(args._isFirst).to.equal(true);
-        expect(args._isLast).to.equal(false);
-        expect(args._total).to.equal(3);
+        expect(args).to.have.property('_isFirst', true);
+        expect(args).to.have.property('_isLast', false);
+        expect(args).to.have.property('_total', 3);
       })
 
       it('should pass a model as the value', function () {


### PR DESCRIPTION
This upgrades handlebars, underscore, peer dependency on 1.0.0 for rendr (although it's probably not need, i haven't tested this stuff against older versions).

the test changes were needed because of the update to chai.