### PR TITLE
Only ship the handlebars runtime to the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 var Handlebars = require('handlebars');
 
+if (Handlebars['default']) {
+  // If we only have the Handlebars runtime available, use that here.
+  // Until Handlebars 3, we have to use 'default' instead of just requiring 'handlebars'.
+  Handlebars = Handlebars['default'];
+}
+
 module.exports = function(options){
   var localExports = {},
       templateFinder = require('./shared/templateFinder')(Handlebars);

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "sinon": "~1.12.2",
     "sinon-chai": "^2.7.0",
     "proxyquire": "^1.3.1"
+  },
+  "browser": {
+    "handlebars": "handlebars/runtime"
   }
 }


### PR DESCRIPTION
On the assumption that everyone is using precompiled templates with this module, we can avoid bundling the Handlebars compiler for delivery to the browser.

I've only done basic click testing but our app seems to work fine with this change, there might be edge cases I haven't considered.

It seemed to save about 73k on the unminified bundle.

What do you think?