### PR TITLE
Allow an instance of templateFinder to be passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var Handlebars = require('handlebars');
 
 module.exports = function(options){
   var localExports = {},
-      templateFinder = require('./shared/templateFinder')(Handlebars);
+      templateFinder = options.templateFinder || require('./shared/templateFinder')(Handlebars);
 
   /**
    * Export the `Handlebars` object, so other modules can add helpers, partials, etc.


### PR DESCRIPTION
This is to allow (in a slightly roundabout way) my application to pass in a pre-`require`d instance of `compiledTemplates` rather than having the template finder `require` it for me (which requires Browserify `expose` settings).