### PR TITLE
remove handlebars as a dependency, let the app the inject it

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ rendr-handlebars
 ================
 
 [Handlebars](http://handlebarsjs.com/) template adapter for [Rendr](https://github.com/rendrjs/rendr) apps.
+This library has been tested using [Handlebars 2.0.0](https://github.com/wycats/handlebars.js/tree/v2.0.0).
+
+If you'd like to use a more recent version number of `Handlebars` for your app, just specify it in the [package.json](https://github.com/rendrjs/rendr/blame/master/README.md#L315) of your app and start testing it.
+
 
 ## Configuration options
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
-var Handlebars = require('handlebars');
+module.exports = function(options, Handlebars) {
 
-if (Handlebars['default']) {
-  // If we only have the Handlebars runtime available, use that here.
-  // Until Handlebars 3, we have to use 'default' instead of just requiring 'handlebars'.
-  Handlebars = Handlebars['default'];
-}
+  if (Handlebars['default']) {
+    // If we only have the Handlebars runtime available, use that here.
+    // Until Handlebars 3, we have to use 'default' instead of just requiring 'handlebars'.
+    Handlebars = Handlebars['default'];
+  }
 
-module.exports = function(options){
   var localExports = {},
-      templateFinder = options.templateFinder || require('./shared/templateFinder')(Handlebars);
+    templateFinder = options.templateFinder || require('./shared/templateFinder')(Handlebars);
 
   /**
    * Export the `Handlebars` object, so other modules can add helpers, partials, etc.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "http://github.com/rendrjs/rendr-handlebars.git"
   },
   "dependencies": {
-    "handlebars": "^2.0.0",
     "underscore": "^1.8.2"
   },
   "peerDependencies": {
@@ -30,6 +29,7 @@
   "devDependencies": {
     "backbone": "~1.1.2",
     "chai": "^2.1.0",
+    "handlebars": "^2.0.0",
     "memo-is": "0.0.2",
     "mocha": "~2.1.0",
     "sinon": "~1.12.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,10 @@
-var assert = require('assert');
+var assert = require('assert'),
+  Handlebars = require('handlebars');
 
 describe("require('rendr-handlebars')", function() {
   it('returns a new templateAdapter', function() {
     var templateAdapter, firstPatternSrc;
-    templateAdapter = require('../index')({entryPath: '/some/place/'})
+    templateAdapter = require('../index')({entryPath: '/some/place/'}, Handlebars);
     assert.equal(templateAdapter.templatePatterns.length, 1);
     firstPatternSrc = templateAdapter.templatePatterns[0].src;
     assert.equal(firstPatternSrc, '/some/place/app/templates/compiledTemplates');
@@ -11,8 +12,8 @@ describe("require('rendr-handlebars')", function() {
 
   it('does not squash an old templateAdapter', function() {
     var templateAdapter1, templateAdapter2, firstPatternSrc, secondPatternSrc;
-    templateAdapter1 = require('../index')({entryPath: '/some/place/'})
-    templateAdapter2 = require('../index')({entryPath: '/some/other/place/'})
+    templateAdapter1 = require('../index')({entryPath: '/some/place/'}, Handlebars);
+    templateAdapter2 = require('../index')({entryPath: '/some/other/place/'}, Handlebars);
     assert.equal(templateAdapter1.templatePatterns.length, 1);
     assert.equal(templateAdapter2.templatePatterns.length, 1);
     firstPatternSrc = templateAdapter1.templatePatterns[0].src;

--- a/test/shared/templateFinder.test.js
+++ b/test/shared/templateFinder.test.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     entryPath = process.cwd() + '/test/fixtures/',
-    templateAdapter = require('../../index')({entryPath: entryPath});
+    Handlebars = require('handlebars'),
+    templateAdapter = require('../../index')({entryPath: entryPath}, Handlebars);
 
 describe('templateFinder', function() {
   describe('getTemplate', function() {


### PR DESCRIPTION
The idea here is to let the Rendr app decide what version of Handlebars to use, decoupling the template adapter from it.
This also solves a possible issue where for example the Rendr app requires Handlebars `3.0.0`and rendr-handlebars here wants `2.0.0`. In that case we would end up with two handlebars modules, one for each `node_modules` folder of Rendr and Rendr-handlebars, that would eventually break the app (i.e it would attach the custom helpers to one of the two Handlebars, while trying to use the other one).

This will need another PR for Rendr merged: https://github.com/rendrjs/rendr/pull/467

What do you think? 