### PR TITLE
fix nested partial view client render issue

### DIFF
--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -32,7 +32,7 @@ module.exports = function (Handlebars) {
       var parentView = getProperty('_view', this, options);
       html = getServerHtml(viewName, viewOptions, parentView);
     } else {
-      html = getClientPlaceholder(viewName, viewOptions);
+      html = getClientPlaceholder(viewName, viewOptions, Handlebars);
     }
 
     return new Handlebars.SafeString(html);
@@ -55,7 +55,7 @@ function getServerHtml(viewName, viewOptions, parentView) {
   return view.getHtml();
 }
 
-function getClientPlaceholder(viewName, viewOptions) {
+function getClientPlaceholder(viewName, viewOptions, Handlebars) {
   if (!BaseView) { BaseView = require('rendr/shared/base/view'); }
   var fetchSummary;
 
@@ -67,7 +67,13 @@ function getClientPlaceholder(viewName, viewOptions) {
 
   // create a list of data attributes
   var attrString = _.inject(viewOptions, function(memo, value, key) {
-    if (_.isArray(value) || _.isObject(value)) { value = JSON.stringify(value); }
+    if (_.isArray(value) || _.isObject(value)) {
+      if (key === '_block' && value.contructor === Handlebars.SafeString) {
+        value = value.string;
+      } else {
+        value = JSON.stringify(value);
+      }
+    }
     return memo += " data-" + key + "=\"" + _.escape(value) + "\"";
   }, '');
 

--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -68,7 +68,7 @@ function getClientPlaceholder(viewName, viewOptions, Handlebars) {
   // create a list of data attributes
   var attrString = _.inject(viewOptions, function(memo, value, key) {
     if (_.isArray(value) || _.isObject(value)) {
-      if (key === '_block' && value.contructor === Handlebars.SafeString) {
+      if (key === '_block' && value instanceof Handlebars.SafeString) {
         value = value.string;
       } else {
         value = JSON.stringify(value);

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -175,6 +175,22 @@ describe('view', function () {
           '<div data-render="true" data-generic_object="{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}" data-fetch_summary="{}" data-view="test"></div>'
         );
       });
+
+      context('when the key is _block and is of type Handlebars.SafeString', function () {
+        it('extracts the string correctly', function () {
+          var html = '<div>something</div>',
+            result = subject.call({
+            _app: app()
+          }, 'test', {
+            hash: {
+              _block: new Handlebars.SafeString(html)
+            }
+          });
+          expect(result.string).to.eq(
+            '<div data-render="true" data-_block="&lt;div&gt;something&lt;/div&gt;" data-fetch_summary="{}" data-view="test"></div>'
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
A view that is comprised of nested partial views fails when rendered on the client.

example emblem setup would be:

partial_1.emblem:

div
    h2 Partial 1
        == _block

partial_2.emblem:

div
    h2 Partial 2
        == _block

sub_view.emblem:

h2 Sub View

main_view.emblem:

= view partial_1
    =view partial_2
        = sub_view