### PR TITLE
Prevent camelCased keys from being passed to the view helper

### DIFF
--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -14,6 +14,16 @@ module.exports = function (Handlebars) {
     viewOptions = options.hash || {};
     app = getProperty('_app', this, options);
 
+    _.forEach(_.omit(viewOptions, 'templateName'), function(value, key) {
+      if (
+        key.match(/[A-Z]/g) &&
+        !app.modelUtils.isModel(value) &&
+        !app.modelUtils.isCollection(value)
+      ) {
+        throw new Error('Template properties should be passed in snake_case: "' + key + '"')
+      }
+    });
+
     // Pass through a reference to the app.
     if (app) {
       viewOptions.app = app;

--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -20,7 +20,9 @@ module.exports = function (Handlebars) {
         !app.modelUtils.isModel(value) &&
         !app.modelUtils.isCollection(value)
       ) {
-        throw new Error('Template properties should be passed in snake_case: "' + key + '"')
+        throw new Error(
+          'Template properties are case-insensitive, suggest using all-lowercase keys to avoid bugs: "' + key + '"'
+        );
       }
     });
 

--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -21,7 +21,7 @@ module.exports = function (Handlebars) {
         !app.modelUtils.isCollection(value)
       ) {
         throw new Error(
-          'Template properties are case-insensitive, suggest using all-lowercase keys to avoid bugs: "' + key + '"'
+          'View option keys are case-insensitive, use all-lowercase keys to avoid bugs: "' + key + '"'
         );
       }
     });

--- a/test/shared/helpers/view.test.js
+++ b/test/shared/helpers/view.test.js
@@ -34,7 +34,9 @@ describe('view', function () {
         return {
           options: { entryPath: '/path' },
           modelUtils: {
-            underscorize: function (name) { return name; }
+            underscorize: function (name) { return name; },
+            isModel: function(model) { return model instanceof ModelClass },
+            isCollection: function(collection) { return collection instanceof CollectionClass }
           }
         };
       });
@@ -189,6 +191,48 @@ describe('view', function () {
           expect(result.string).to.eq(
             '<div data-render="true" data-_block="&lt;div&gt;something&lt;/div&gt;" data-fetch_summary="{}" data-view="test"></div>'
           );
+        });
+      });
+    });
+
+    context('when the viewOptions contains camelCased keys', function() {
+      context('when the key is templateName', function() {
+        it('does not throw an error', function() {
+          expect(subject.bind({
+            _app: app()
+          }, 'test', {
+            hash: { templateName: 'someTemplate' }
+          })).to.not.throw(Error);
+        });
+      });
+
+      context('when the value is a model', function() {
+        it('does not throw an error', function() {
+          expect(subject.bind({
+            _app: app()
+          }, 'test', {
+            hash: { myModel: new ModelClass() }
+          })).to.not.throw(Error);
+        });
+      });
+
+      context('when the value is a collection', function() {
+        it('does not throw an error', function() {
+          expect(subject.bind({
+            _app: app()
+          }, 'test', {
+            hash: { myCollection: new CollectionClass() }
+          })).to.not.throw(Error);
+        });
+      });
+
+      context('when the key is not templateName, and the value is not a model or a collection', function() {
+        it('throws an error', function() {
+          expect(subject.bind({
+            _app: app()
+          }, 'test', {
+            hash: { camelCased: 'ohno' }
+          })).to.throw(Error);
         });
       });
     });


### PR DESCRIPTION
Rendr handles camelCased keys just fine when rendering on the server side, but chokes during rehydration, causing confusing errors and discrepancies between server-rendered and client-rendered pages.

This error tripped me up when first starting, and can go by unnoticed if only testing a page by rendering it on the server. I helped someone troubleshoot this today and decided to find out if I could make the check automated.
