### PR TITLE
Double-escape data attributes in client side view placeholder

### DIFF
--- a/shared/helpers/view.js
+++ b/shared/helpers/view.js
@@ -74,7 +74,7 @@ function getClientPlaceholder(viewName, viewOptions, Handlebars) {
         value = JSON.stringify(value);
       }
     }
-    return memo += " data-" + key + "=\"" + _.escape(value) + "\"";
+    return memo += " data-" + key + "=\"" + _.escape(_.escape(value)) + "\"";
   }, '');
 
   return '<div data-render="true"' + attrString +' data-view="'+ viewName +'"></div>';


### PR DESCRIPTION
We're experiencing some XSS issues in a specific case. Some _escaped_ content is supplied as the block to a view:

```
= view "showcontent"
    == content
```

`content` here is set to `"<p>&lt;script&gt;alert('BOOM')&lt;/script&gt;</p>"`

And the 'showcontent' view displays the content:

```
span class='content'
    == _block
```

On a server-rendered view of this page, the content is displayed safely:

![image](https://cloud.githubusercontent.com/assets/608480/13697231/82468c0a-e718-11e5-995a-cea5c4fe553a.png)

But when navigating client-side to this page, the script is actually executed:

![image](https://cloud.githubusercontent.com/assets/608480/13697249/a5082c58-e718-11e5-9064-e101af558479.png)

I think the cause is that when [we call `this.$el.html(html)`](https://github.com/rendrjs/rendr/blob/554984e5cc91e56b82fe8ed005fe076ea32d32eb/shared/base/view.js#L212) to render a view, the content is _automatically unescaped_ by virtue of setting it as the innerHTML of a DOM element. So, although [we do `_.escape` the attributes](https://github.com/rendrjs/rendr-handlebars/blob/df63328f94f9382bac6b3af760ea167ef501c401/shared/helpers/view.js#L77) we create in the client placeholder, it's immediately undone as soon as it hits the DOM, so that when we eventually [`_.unescape` it in `BaseView.getViewOptions`](https://github.com/rendrjs/rendr-handlebars/blob/df63328f94f9382bac6b3af760ea167ef501c401/shared/helpers/view.js#L77), it's actually unescaped _one time too many_ meaning our previously safe content is now unsafe.

Double-escaping the attribute values when creating the client placeholder attributes seems to result in rendered attributes that are consistent with server-rendered output.
